### PR TITLE
Correct true return value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,1 @@
-all:
-	gcc -o true true.c
+all: true

--- a/true.c
+++ b/true.c
@@ -1,1 +1,1 @@
-int main() {}
+int main() { return 0; }


### PR DESCRIPTION
true was missing a return statement, resulting in it returning garbage,
which was usually actually non-zero.  Correct this by adding a return
statement.

Offset the 11 characters added by removing a net of 15 characters from
the Makefile.  GNU Make's implicit rules will handle compilation just
fine.
